### PR TITLE
Add more target frameworks

### DIFF
--- a/Serilog.Enrichers.OpenTelemetry/Serilog.Enrichers.OpenTelemetry.csproj
+++ b/Serilog.Enrichers.OpenTelemetry/Serilog.Enrichers.OpenTelemetry.csproj
@@ -14,7 +14,7 @@
         <RepositoryUrl>https://github.com/Freheims/Serilog.Enrichers.OpenTelemetry</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.1</Version>
+        <Version>1.1.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Serilog.Enrichers.OpenTelemetry/Serilog.Enrichers.OpenTelemetry.csproj
+++ b/Serilog.Enrichers.OpenTelemetry/Serilog.Enrichers.OpenTelemetry.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Title>Serilog.Enrichers.OpenTelemetry</Title>
         <Description>Serilog enricher to add OpenTelemetry TraceId and SpanId</Description>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Serilog.Enrichers.OpenTelemetry</PackageId>


### PR DESCRIPTION
I just added more target frameworks, as it so happens that I still use old .NET 6 on my project, so upgrading is not an option.
Can PR be merged and deployed to Nuget, please?